### PR TITLE
add auxiliary functions to call on()

### DIFF
--- a/WolmoReactiveCore/Signal.swift
+++ b/WolmoReactiveCore/Signal.swift
@@ -131,32 +131,89 @@ public extension Signal where Value: ResultProtocol {
 
 }
 
+public extension Signal {
+
+    /**
+     - parameter handler: closure to execute upon value.
+
+     Inject side effects to be performed upon a value event.
+     */
+    func onValue(_ handler: @escaping (Value) -> Void ) -> Signal {
+        return on(value: handler)
+    }
+
+    /**
+     - parameter handler: closure to execute upon error.
+
+     Inject side effects to be performed upon an error event.
+     */
+    func onError(_ handler: @escaping (Error) -> Void ) -> Signal {
+        return on(failed: handler)
+    }
+
+    /**
+     - parameter handler: closure to execute upon signal disposal.
+
+     Inject side effects to be performed upon disposing the signal.
+     */
+    func onDisposed(_ handler: @escaping () -> Void ) -> Signal {
+        return on(disposed: handler)
+    }
+
+    /**
+     - parameter handler: closure to execute upon Completion.
+
+     Inject side effects to be performed upon a Completed event.
+     */
+    func onCompleted(_ handler: @escaping () -> Void ) -> Signal {
+        return on(completed: handler)
+    }
+
+    /**
+     - parameter handler: closure to execute upon Termination.
+
+     Inject side effects to be performed upon a terminating event (interrupted, completed, error).
+     */
+    func onTerminated(_ handler: @escaping () -> Void ) -> Signal {
+        return on(terminated: handler)
+    }
+
+    /**
+     - parameter handler: closure to execute upon interruption.
+
+     Inject side effects to be performed upon an interrupted event.
+     */
+    func onInterrupted(_ handler: @escaping () -> Void ) -> Signal {
+        return on(interrupted: handler)
+    }
+}
+
 public protocol ResultProtocol {
     associatedtype Value
     associatedtype Error: Swift.Error
-    
+
     init(value: Value)
     init(error: Error)
-    
+
     var result: Result<Value, Error> { get }
 }
 
 extension Result: ResultProtocol {
-    
+
     /// Constructs a success wrapping a `value`.
     public init(value: Value) {
         self = .success(value)
     }
-    
+
     /// Constructs a failure wrapping an `error`.
     public init(error: Error) {
         self = .failure(error)
     }
-    
+
     public var result: Result<Value, Error> {
         return self
     }
-    
+
     /// Returns the value if self represents a success, `nil` otherwise.
     public var value: Value? {
         switch self {
@@ -164,7 +221,7 @@ extension Result: ResultProtocol {
         case .failure: return nil
         }
     }
-    
+
     /// Returns the error if self represents a failure, `nil` otherwise.
     public var error: Error? {
         switch self {

--- a/WolmoReactiveCore/SignalProducer.swift
+++ b/WolmoReactiveCore/SignalProducer.swift
@@ -126,3 +126,78 @@ public extension SignalProducer where Value: ResultProtocol {
     }
     
 }
+
+public extension SignalProducer {
+    
+    /**
+     - parameter handler: closure to execute upon value.
+     
+     Inject side effects to be performed upon a value event.
+     */
+    func onValue(_ handler: @escaping (Value) -> Void ) -> SignalProducer {
+        return on(value: handler)
+    }
+    
+    /**
+     - parameter handler: closure to execute upon error.
+     
+     Inject side effects to be performed upon an error event.
+     */
+    func onError(_ handler: @escaping (Error) -> Void ) -> SignalProducer {
+        return on(failed: handler)
+    }
+    
+    /**
+     - parameter handler: closure to execute upon disposing the producer.
+     
+     Inject side effects to be performed upon disposing the producer.
+     */
+    func onDisposed(_ handler: @escaping () -> Void ) -> SignalProducer {
+        return on(disposed: handler)
+    }
+    
+    /**
+     - parameter handler: closure to execute upon completion.
+     
+     Inject side effects to be performed upon a completed event.
+     */
+    func onCompleted(_ handler: @escaping () -> Void ) -> SignalProducer {
+        return on(completed: handler)
+    }
+    
+    /**
+     - parameter handler: closure to execute upon termination.
+     
+     Inject side effects to be performed upon a terminating event (completed, interrupted, error).
+     */
+    func onTerminated(_ handler: @escaping () -> Void ) -> SignalProducer {
+        return on(terminated: handler)
+    }
+    
+    /**
+     - parameter handler: closure to execute after starting the producer.
+     
+     Inject side effects to be performed after starting the producer.
+     */
+    func onStarted(_ handler: @escaping () -> Void ) -> SignalProducer {
+        return on(started: handler)
+    }
+    
+    /**
+     - parameter handler: closure to execute before starting the producer.
+     
+     Inject side effects to be performed before starting the producer.
+     */
+    func onStarting(_ handler: @escaping () -> Void ) -> SignalProducer {
+        return on(starting: handler)
+    }
+    
+    /**
+     - parameter handler: closure to execute upon interruption.
+     
+     Inject side effects to be performed upon an interrupted event.
+     */
+    func onInterrupted(_ handler: @escaping () -> Void ) -> SignalProducer {
+        return on(interrupted: handler)
+    }
+}

--- a/WolmoReactiveCoreTests/SignalProducerSpec.swift
+++ b/WolmoReactiveCoreTests/SignalProducerSpec.swift
@@ -110,6 +110,150 @@ public class SignalProducerSpec: QuickSpec {
 
         }
         
+        describe("#onValue") {
+            
+            context("when sending a value") {
+                
+                it("should perform the given side effects") { waitUntil { done in
+                    let producer = SignalProducer<(), NSError> { observer, _ in
+                        observer.send(value: ())
+                    }
+                    producer.onValue { done() }.start()
+                    }
+                }
+                
+            }
+            
+        }
+        
+        describe("#onStarted") {
+            
+            context("when starting a producer") {
+                
+                it("should perform the given side effects") { waitUntil { done in
+                    let producer = SignalProducer<(), NSError> { observer, _ in }
+                    producer.onStarted { done() }.start()
+                    }
+                }
+                
+            }
+            
+        }
+        
+        describe("#onStarting") {
+            
+            context("when starting a producer") {
+                
+                it("should perform the given side effects") { waitUntil { done in
+                    let producer = SignalProducer<(), NSError> { observer, _ in }
+                    producer.onStarting { done() }.start()
+                    }
+                }
+                
+            }
+            
+        }
+        
+        describe("#onError") {
+            
+            context("when sending an error") {
+                
+                it("should perform the given side effects") { waitUntil { done in
+                    let producer = SignalProducer<(), NSError> { observer, _ in
+                        observer.send(error: NSError(domain: "", code: 0, userInfo: [:]))
+                    }
+                    producer.onError { _ in done() }.start()
+                    }
+                }
+                
+            }
+            
+        }
+        
+        describe("#onTerminated") {
+            
+            context("when sending an error") {
+                
+                it("should perform the given side effects") { waitUntil { done in
+                    let producer = SignalProducer<(), NSError> { observer, _ in
+                        observer.send(error: NSError(domain: "", code: 0, userInfo: [:]))
+                    }
+                    producer.onTerminated { done() }.start()
+                    }
+                }
+                
+            }
+            
+            context("when sending completed") {
+                
+                it("should perform the given side effects") { waitUntil { done in
+                    let producer = SignalProducer<(), NSError> { observer, _ in
+                        observer.sendCompleted()
+                    }
+                    producer.onTerminated { done() }.start()
+                    }
+                }
+                
+            }
+            
+            context("when disposing the producer") {
+                
+                it("should perform the given side effects") { waitUntil { done in
+                    let producer = SignalProducer<(), NSError> { observer, _ in }
+                    producer.onTerminated { done() }.start().dispose()
+                    }
+                }
+                
+            }
+            
+        }
+        
+        describe("#onCompleted") {
+            
+            context("when sending completed") {
+                
+                it("should perform the given side effects") { waitUntil { done in
+                    let producer = SignalProducer<(), NSError> { observer, _ in
+                        observer.sendCompleted()
+                    }
+                    producer.onCompleted { done() }.start()
+                    }
+                }
+                
+            }
+            
+        }
+        
+        describe("#onDisposed") {
+            
+            context("when disposing the producer") {
+                
+                it("should perform the given side effects") { waitUntil { done in
+                    let producer = SignalProducer<(), NSError> { observer, _ in }
+                    producer.onDisposed { done() }.start().dispose()
+                    }
+                }
+                
+            }
+            
+        }
+        
+        describe("#onInterrupted") {
+            
+            context("when interrupting the producer") {
+                
+                it("should perform the given side effects") { waitUntil { done in
+                    let producer = SignalProducer<(), NSError> { observer, _ in
+                        observer.sendInterrupted()
+                    }
+                    producer.onInterrupted { done() }.start()
+                    }
+                }
+                
+            }
+            
+        }
+        
         describe("#toResultSignalProducer") {
 
             context("When sending a value") {

--- a/WolmoReactiveCoreTests/SignalSpec.swift
+++ b/WolmoReactiveCoreTests/SignalSpec.swift
@@ -351,6 +351,118 @@ public class SignalSpec: QuickSpec {
             
         }
         
+        describe("#onValue") {
+            
+            context("when sending a value") {
+                
+                it("should perform the given side effects") { waitUntil { done in
+                    let (signal, observer) = Signal<(), NoError>.pipe()
+                    signal.onValue { _ in done() }.observeValues { _ in }
+                    observer.send(value: ())
+                    }
+                }
+                
+            }
+            
+        }
+        
+        describe("#onError") {
+            
+            context("when sending an error") {
+                
+                it("should perform the given side effects") { waitUntil { done in
+                    let (signal, observer) = Signal<(), NSError>.pipe()
+                    signal.onError { _ in done() }.observeResult { _ in }
+                    observer.send(error: NSError(domain: "", code: 0, userInfo: [:]))
+                    }
+                }
+                
+            }
+            
+        }
+        
+        describe("#onTerminated") {
+            
+            context("when sending an error") {
+                
+                it("should perform the given side effects") { waitUntil { done in
+                    let (signal, observer) = Signal<(), NSError>.pipe()
+                    signal.onTerminated { done() }.observeResult { _ in }
+                    observer.send(error: NSError(domain: "", code: 0, userInfo: [:]))
+                    }
+                }
+                
+            }
+            
+            context("when sending completed") {
+                
+                it("should perform the given side effects") { waitUntil { done in
+                    let (signal, observer) = Signal<(), NSError>.pipe()
+                    signal.onTerminated { done() }.observeResult { _ in }
+                    observer.sendCompleted()
+                    }
+                }
+                
+            }
+            
+            context("when interrupting the signal") {
+                
+                it("should perform the given side effects") { waitUntil { done in
+                    let (signal, observer) = Signal<(), NSError>.pipe()
+                    signal.onTerminated { done() }.observeResult { _ in }
+                    observer.sendInterrupted()
+                    }
+                }
+                
+            }
+            // unlike the producer, disposing a signal doesn't terminate it, so we are not testing that case
+            
+        }
+        
+        describe("#onCompleted") {
+            
+            context("when interrupting the signal") {
+                
+                it("should perform the given side effects") { waitUntil { done in
+                    let (signal, observer) = Signal<(), NSError>.pipe()
+                    signal.onInterrupted { done() }.observeResult { _ in }
+                    observer.sendInterrupted()
+                    }
+                }
+                
+            }
+            
+        }
+        
+        describe("#onInterrupted") {
+            
+            context("when interrupting ") {
+                
+                it("should perform the given side effects") { waitUntil { done in
+                    let (signal, observer) = Signal<(), NSError>.pipe()
+                    signal.onCompleted { done() }.observeResult { _ in }
+                    observer.sendCompleted()
+                    }
+                }
+                
+            }
+            
+        }
+        
+        describe("#onDisposed") {
+            
+            context("when disposing the signal") {
+                
+                it("should perform the given side effects") { waitUntil { done in
+                    let (signal, _) = Signal<(), NSError>.pipe()
+                    signal.onDisposed { done() }.observeResult { _ in }?.dispose()
+                    }
+                }
+                
+            }
+            
+        }
+        
     }
     
 }

--- a/WolmoReactiveCoreTests/SignalSpec.swift
+++ b/WolmoReactiveCoreTests/SignalSpec.swift
@@ -356,7 +356,7 @@ public class SignalSpec: QuickSpec {
             context("when sending a value") {
                 
                 it("should perform the given side effects") { waitUntil { done in
-                    let (signal, observer) = Signal<(), NoError>.pipe()
+                    let (signal, observer) = Signal<(), Never>.pipe()
                     signal.onValue { _ in done() }.observeValues { _ in }
                     observer.send(value: ())
                     }


### PR DESCRIPTION
Description: add auxiliary functions to call on() for a single event, for example:

`getUsers.onValue { value in ... }.start()`

instead of:

`getUsers.on(value: { value in ...}).start()`